### PR TITLE
Updated GirlGenius to new markup

### DIFF
--- a/dosagelib/plugins/g.py
+++ b/dosagelib/plugins/g.py
@@ -111,10 +111,10 @@ class GirlGenius(_BasicScraper):
     stripUrl = url + '?date=%s'
     firstStripUrl = stripUrl % '20021104'
     imageSearch = compile(tagre("img", "src", r"(%sggmain/strips/[^']*)" % rurl, quote="'"))
-    prevSearch = compile(tagre("a", "href", r"(%s[^']+)" % rurl, quote="'") +
-        tagre("img", "alt", "The Previous Comic", quote="'"))
+    prevSearch = compile(tagre("a", "id", "topprev", quote="\"",
+                            before=r"(%s[^\"']+)" % rurl))
+    multipleImagesPerStrip = True
     help = 'Index format: yyyymmdd'
-
 
 class GirlsWithSlingshots(_BasicScraper):
     url = 'http://www.girlswithslingshots.com/'


### PR DESCRIPTION
GG markup has changed, so I fixed the prevSearch regex to find the
"previous" button on the redesigned page.

As well, I set multipleImagesPerStrip to true, since there are quite a
few comics with multiple images that were being discarded.
